### PR TITLE
make message $M$ also an element in q-order subgroup

### DIFF
--- a/elgamal.py
+++ b/elgamal.py
@@ -208,9 +208,6 @@ def find_prime(iNumBits, iConfidence):
 #encodes bytes to integers mod p.  reads bytes from file
 def encode(sPlaintext, iNumBits, p):
 		byte_array = bytearray(sPlaintext, 'utf-16')
-		q = (p - 1) // 2
-		qf = (q + 1) // 2
-
 		#z is the array of integers mod p
 		z = []
 


### PR DESCRIPTION
Hi @RyanRiddle 

This is the final solution I found to secure the message space. 

By squaring the message $M->M^2$, it becomes an element in q-order subgroup. Interestingly, by powering $(q+1)//2$, we can get the unique square root. So decoding is easy.

This makes this library semantic secure. 

Disadvantage: no compatible with old ciphertexts.