### PR TITLE
Tests of find_primitime_root

### DIFF
--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -25,6 +25,11 @@ class GreatestCommonDivisorTests(unittest.TestCase):
     def test_not_coprime(self):
         self.assertNotEqual(elgamal.gcd(10, 20), 1)
 
+    def test_find_primitive_root(self):
+        self.assertIn(elgamal.find_primitive_root(7), [3, 5])
+        self.assertIn(elgamal.find_primitive_root(11), [2, 6, 7, 8])
+        self.assertIn(elgamal.find_primitive_root(43), [3, 5, 12, 18, 19, 20, 26, 28, 29, 30, 33, 34])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Tested  ``find_primitime_root`` function over known values from here https://en.wikipedia.org/wiki/Primitive_root_modulo_n#Elementary_example

So something goes wrong. Pretty often your function generate wrong value. 

Prepared tests to check it.
To reproduce need to run tests several times.